### PR TITLE
support root dir tgz request

### DIFF
--- a/lib/handle-cfg.js
+++ b/lib/handle-cfg.js
@@ -271,6 +271,3 @@ function findAdapter(cfg) {
 function relative(from, to) {
   return path.relative(from, to).replace(path.sep, '/')
 }
-
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var logger = require('./logger')
 var handleCfg = require('./handle-cfg')
 var report = require('./report')
 var getRepo = require('./get-repo')
+var tgz = require('./tgz')
 
 
 module.exports = Client
@@ -49,6 +50,8 @@ Client.prototype.launchServer = function(callback) {
   process.chdir(root)
 
   var app = express()
+  app.use(express.query())
+  app.use(tgz({root: root}))
   app.use(express.static(root))
 
   app.listen(cfg.clientPort, cfg.clientHost, function() {
@@ -109,6 +112,9 @@ Client.prototype.launchTest = function() {
         case 'info':
         case 'warn':
         case 'error':
+          if (!Array.isArray(info)) {
+            info = [info];
+          }
           logger[action].apply(logger, info)
           break
         case 'autoBrowsers':
@@ -137,23 +143,23 @@ Client.prototype.launchTest = function() {
     }
 
     http.request(opts, function(res) {
-      var buffer = new Buffer(parseInt(res.headers['content-length'], 10))
-      var offset = 0
+      var totalLength = 0
 
+      var bufs = [];
       res.on('data', function(data) {
-        data.copy(buffer, offset)
-        offset += data.length
+        totalLength += data.length
+        bufs.push(data);
       })
 
       res.on('end', function() {
+        var body = Buffer.concat(bufs, totalLength)
         socket.emit('proxyRes', {
           path: info.path,
           statusCode: res.statusCode,
           headers: res.headers,
-          body: buffer
+          body: body
         })
       })
-
     }).on('error', function(err) {
       logger.warn('Proxy error <', err, '>')
       socket.emit('proxyRes', {
@@ -161,7 +167,6 @@ Client.prototype.launchTest = function() {
         statusCode: 500,
         body: err
       })
-
     }).end()
   })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,11 +153,19 @@ Client.prototype.launchTest = function() {
 
       res.on('end', function() {
         var body = Buffer.concat(bufs, totalLength)
+        // socket.io not support Buffer until 1.0.0
+        // need to transfer Buffer to bytes array
+        var bytes = [];
+        for (var i = 0; i < body.length; i++) {
+          bytes[i] = body[i];
+        }
+        logger.info('proxyRes, path: %s, status: %s, body size: %s',
+          info.path, res.statusCode, body.length)
         socket.emit('proxyRes', {
           path: info.path,
           statusCode: res.statusCode,
           headers: res.headers,
-          body: body
+          body: bytes,
         })
       })
     }).on('error', function(err) {

--- a/lib/tgz.js
+++ b/lib/tgz.js
@@ -1,0 +1,63 @@
+/**!
+ * totoro - lib/tgz.js
+ *
+ * Copyright(c) fengmk2 and other contributors.
+ * MIT Licensed
+ *
+ * Authors:
+ *   fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var tar = require('tar')
+var fstream = require('fstream')
+var fs = require('fs')
+var zlib = require('zlib')
+var path = require('path')
+var ignore = require('ignore')
+var logger = require('./logger')
+
+module.exports = function (options) {
+  var root = options.root
+  if (root[root.length - 1] !== '/') {
+    root += '/'
+  }
+
+  var gitignore = ignore();
+  var gitignoreFile = path.join(root, '.gitignore')
+  if (fs.existsSync(gitignoreFile)) {
+    gitignore.addIgnoreFile(gitignoreFile);
+  }
+  gitignore.addPattern(['node_modules', '.git'])
+
+  return function (req, res, next) {
+    if (req.query.__totoro_root_tgz !== 'true') {
+      return next()
+    }
+    logger.info('tgz %s by req: %s', root, req.url)
+    packDirectory(root, gitignore).pipe(res)
+  }
+}
+
+function packDirectory(root, gitignore) {
+  // This must be a "directory"
+  var ws = fstream.Reader({ path: root, type: 'Directory',
+    filter: function (entry) {
+      var fullpath = entry.path.replace(root, '')
+      if (gitignore.filter([fullpath]).length === 0) {
+        return false;
+      }
+      logger.debug('tgz dir: %s', fullpath)
+      return true;
+    }
+  })
+  .pipe(tar.Pack({ noProprietary: true }))
+  .pipe(zlib.createGzip())
+
+  return ws
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
         "colorful": "2.1.0",
         "tracer": "0.5.1",
         "request": "2.21.0",
-        "totoro-common": "0.1.5"
+        "totoro-common": "0.1.5",
+        "fstream": "0.1.28",
+        "tar": "0.1.20",
+        "ignore": "2.2.14"
     },
     "devDependencies": {
         "grunt": "0.4.1",


### PR DESCRIPTION
- 通过 `?__totoro_root_tgz=true` 参数, 将当前 root 目录下的文件打包给 nodejs driver 下载
- 修复 socket.io < 1.0.0 无法传输 Buffer 的问题
