### PR TITLE
docs: Fix simple typo, occured -> occurred

### DIFF
--- a/examples/sea-modules/gallery/event-simulate/1.0.0/event-simulate-debug.js
+++ b/examples/sea-modules/gallery/event-simulate/1.0.0/event-simulate-debug.js
@@ -259,13 +259,13 @@ define("gallery/event-simulate/1.0.0/event-simulate-debug", [ "$-debug" ], funct
      * @param {int} detail (Optional) The number of times the mouse button has
      *      been used. The default value is 1.
      * @param {int} screenX (Optional) The x-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} screenY (Optional) The y-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientX (Optional) The x-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientY (Optional) The y-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {Boolean} ctrlKey (Optional) Indicates if one of the CTRL keys
      *      is pressed while the event is firing. The default is false.
      * @param {Boolean} altKey (Optional) Indicates if one of the ALT keys
@@ -528,13 +528,13 @@ define("gallery/event-simulate/1.0.0/event-simulate-debug", [ "$-debug" ], funct
      * @param {int} detail (Optional) Specifies some detail information about 
      *      the event depending on the type of event.
      * @param {int} screenX (Optional) The x-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} screenY (Optional) The y-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientX (Optional) The x-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientY (Optional) The y-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {Boolean} ctrlKey (Optional) Indicates if one of the CTRL keys
      *      is pressed while the event is firing. The default is false.
      * @param {Boolean} altKey (Optional) Indicates if one of the ALT keys
@@ -645,13 +645,13 @@ define("gallery/event-simulate/1.0.0/event-simulate-debug", [ "$-debug" ], funct
      * @param {int} detail (Optional) Specifies some detail information about 
      *      the event depending on the type of event.
      * @param {int} screenX (Optional) The x-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} screenY (Optional) The y-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientX (Optional) The x-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientY (Optional) The y-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {Boolean} ctrlKey (Optional) Indicates if one of the CTRL keys
      *      is pressed while the event is firing. The default is false.
      * @param {Boolean} altKey (Optional) Indicates if one of the ALT keys

--- a/examples/sea-modules/jquery/jquery/1.7.2/jquery-debug.js
+++ b/examples/sea-modules/jquery/jquery/1.7.2/jquery-debug.js
@@ -8249,7 +8249,7 @@ if ( jQuery.support.ajax ) {
 							xml;
 
 						// Firefox throws exceptions when accessing properties
-						// of an xhr when a network error occured
+						// of an xhr when a network error occurred
 						// http://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_(NS_ERROR_NOT_AVAILABLE)
 						try {
 


### PR DESCRIPTION
There is a small typo in examples/sea-modules/gallery/event-simulate/1.0.0/event-simulate-debug.js, examples/sea-modules/jquery/jquery/1.7.2/jquery-debug.js.

Should read `occurred` rather than `occured`.

